### PR TITLE
Fix: Example for module.json

### DIFF
--- a/docs/develop/modules-structure.md
+++ b/docs/develop/modules-structure.md
@@ -78,7 +78,7 @@ Available attributes:
 	- **role** -  The author's role (e.g. developer or translator)
 
 
-Example `module.php` file:
+Example `module.json` file:
 
 ```json
 {


### PR DESCRIPTION
In the text it shows module.php when module.json should be shown