### PR TITLE
Fix: Using wrong command causes error 404 with PrettyUrl

### DIFF
--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -151,7 +151,7 @@ To enable URL Rewriting in Apache 2.4 based installations it is usually sufficie
 
 ```bash
 cd /var/www/humhub
-cp .htaccess.dist .htaccess
+mv .htaccess.dist .htaccess
 ```
 
 Sometimes it is necessary to enable support for ``.htaccess`` files in the [Apache VirtualHost](server-setup.md#apache) via the ``AllowOverwrite all`` directive. 


### PR DESCRIPTION
If you use `cp` this just copies the entered file which will cause an error 404 because of PrettyUrl being enabled use `mv` to change the name of the file instead @luke- or @buddh4  :+1: 