### PR TITLE
Update server-setup.md

### DIFF
--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -138,7 +138,7 @@ apt install apache2 \
 	php-fpm 
 ```
 
-Create configuration file ``/etc/apache2/site-available/humhub.conf`` with the following content:
+Create configuration file ``/etc/apache2/sites-available/humhub.conf`` with the following content:
 
 
 ```apacheconf


### PR DESCRIPTION
On Ubuntu 20.xx the path is: "/etc/apache2/sites-available" and not "/etc/apache2/site-available"

But I am not a Apache Spezialist please verify before you accept this change!