### PR TITLE
Fix: Directory Layout is now Legacy

### DIFF
--- a/docs/develop/snippet.md
+++ b/docs/develop/snippet.md
@@ -104,7 +104,7 @@ return [
 ];
 ```
 
-### Directory Layout
+### Directory Layout (Legacy)
 
 Adding the following in your module's `config.php` file will enable the view of your snippet in your Directory.
 


### PR DESCRIPTION
The Directory core module is now no more, so the Layout should be marked as Legacy, I also believe it should still be around in the docs just for information for those that use older versions of HumHub.