### PR TITLE
Add note for plesk (allow symlinks following)

### DIFF
--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -167,6 +167,11 @@ cp .htaccess.dist .htaccess
 Sometimes it is necessary to enable support for ``.htaccess`` files in the [Apache VirtualHost](server-setup.md#apache) via the ``AllowOverwrite all`` directive. 
 
 
+:::note
+**Plesk:** Some providers enable the option "Restrict the ability to follow symbolic links" by default. This should be turned off (Websites & Domains > Hosting & DNS > Apache & nginx Settings).
+:::
+
+
 Example VirtualHost configuration:
 
 ```


### PR DESCRIPTION
I've just installed a HumHub instance on a Plesk webhosting (at Serverstation54). There the option "Restrict the ability to follow symbolic links" was disabled by default which lead to errors when enabling Pretty URLs for HumHub. So I thought it would be good to leave a note in the docs.