### PR TITLE
Update notifications

### DIFF
--- a/docs/develop/notifications.md
+++ b/docs/develop/notifications.md
@@ -44,10 +44,11 @@ class SomethingHappend extends BaseNotification
 {
     // Module Id (required)
     public $moduleId = "example";
-    
+
     // Viewname (optional)
-    public $viewName = 'newLike';
+    public $viewName = "somethingHappend";
     
+    // Content
     public function html()
     {
         return Yii::t('SomethingHappend.views_notifications_somethingHappened', "%someUser% did something cool.", [

--- a/docs/develop/notifications.md
+++ b/docs/develop/notifications.md
@@ -44,28 +44,22 @@ class SomethingHappend extends BaseNotification
 {
     // Module Id (required)
     public $moduleId = "example";
-
-    // Viewname (required)
-    public $viewName = "somethingHappend";
+    
+    // Viewname (optional)
+    public $viewName = 'newLike';
+    
+    public function html()
+    {
+        return Yii::t('SomethingHappend.views_notifications_somethingHappened', "%someUser% did something cool.", [
+            '%someUser%' => '<strong>' . Html::encode($originator->displayName) . '</strong>'
+        ]);
+    }
 }
 ```
 
-#### Notification View
+#### Mail View
 
-By default, the view of a notification should be located inside `notifications/views`.
-The view of the example above should therefore be located in `mymodule/notifications/views/somethingHappened.php`.
-
-```php
-<?php
-
-use yii\helpers\Html;
-
-echo Yii::t('SomethingHappend.views_notifications_somethingHappened', "%someUser% did something cool.", [
-    '%someUser%' => '<strong>' . Html::encode($originator->displayName) . '</strong>'
-]);
-```
-
-> Info: If you require a different notification view for mails, you have to add an extra view file to `notifications/views/mail`. 
+If you require a different notification view for mails, you have to add an extra view file to `notifications/views/mail`. 
 
 ## Send Notifications
 

--- a/docs/develop/notifications.md
+++ b/docs/develop/notifications.md
@@ -37,6 +37,8 @@ namespace johndoe\example\notifications;
 
 use humhub\modules\notification\components\BaseNotification;
 
+use yii\helpers\Html;
+
 /**
  * Notifies a user about something happend
  */

--- a/docs/develop/notifications.md
+++ b/docs/develop/notifications.md
@@ -58,9 +58,12 @@ class SomethingHappend extends BaseNotification
 }
 ```
 
-#### Mail View
+#### Notification View (optional)
 
-If you require a different notification view for mails, you have to add an extra view file to `notifications/views/mail`. 
+By default, the view of a notification should be located inside `notifications/views`.
+The view of the example above should therefore be located in `mymodule/notifications/views/somethingHappened.php`.
+
+> Info: If you require a different notification view for mails, you have to add an extra view file to `notifications/views/mail`. 
 
 ## Send Notifications
 


### PR DESCRIPTION
The notifications section for developers seems a bit outdated.
I have corrected the following points:
- viewName is not required
- moved example content to hmtl() instead of view file