### PR TITLE
Update password strength for special char

### DIFF
--- a/docs/admin/security.md
+++ b/docs/admin/security.md
@@ -52,7 +52,7 @@ return [
                 '/^.{8,}$/' => 'Password needs to be at least 8 characters long.',
                 '/^(.*?[A-Z]){2,}.*$/' => 'Password has to contain two uppercase letters.',
                	'/^(.*?[a-z]){1,}.*$/' => 'Password has to contain one lower case letter.',
-               	'/^(.*?=.*[!@#$&*]).*$/' => 'Password has to contain one special case letter.',
+               	'/^(.*?[\W]){1,}.*$/' => 'Password has to contain one special case letter.',
                	'/^(.*?[0-9]){1,}.*$/' => 'Password has to contain one digit.',
             ]
         ]


### PR DESCRIPTION
Not tested much and I'm not a regex expert, but the previous regex wasn't working with `*` char (and definitively others). `\W` insure with have at least a non-word characters. Tested with `*` char