### PR TITLE
Fixing IMGS

### DIFF
--- a/docs/admin/modules.md
+++ b/docs/admin/modules.md
@@ -10,17 +10,17 @@ HumHub utilizes a modular system for customization, enhanced stability, and vers
 ### Installing Modules
 Modules can be easily installed through HumHub's integrated marketplace. To browse, install, and activate modules, navigate to **Profile Dropdown > Marketplace**.
 
-<img src="images/hh-docs-navigate-to-marketplace.png" alt="Navigate to Marketplace" height="256px"/>
+![Navigate to Marketplace](images/hh-docs-navigate-to-marketplace.png)
 
 ### Installing purchased Modules
 To activate a license for individually purchased modules, navigate to **Marketplace > Settings > Add License Key**. After adding the license key, the module will be available for installation.
 
-<img src="images/hh-docs-add-license-key.png" alt="Add License Key" height="256px"/>
+![Add License Key](images/hh-docs-add-license-key.png)
 
 ### Activating & Installing Modules of the HumHub Professional Edition
 To activate HumHub Professional Edition, navigate to **Administration > Information > Upgrade to Professional Edition**. After activation, all Professional Edition modules will be available for installation on the Marketplace.
 
-<img src="images/hh-docs-activate-pe.png" alt="Activate Professional Edition" height="256px"/>
+![Activate Professional Edition](images/hh-docs-activate-pe.png)
 
 ### Installing Modules manually
 Modules available in the integrated marketplace can also be sourced from the [HumHub Marketplace](https://marketplace.humhub.com/). This includes both paid Professional Edition modules and free modules. These modules, including custom modules or those not available in the official Marketplace, can be manually installed by uploading the module `module_name.zip` and unpacking it into the `protected/modules` directory.
@@ -29,17 +29,17 @@ Modules available in the integrated marketplace can also be sourced from the [Hu
 
 After unpacking the custom module into the directory, navigate to **Administration > Modules** and activate the module.
 
-<img src="images/hh-docs-activate-module.png" alt="Activate Module" height="256px"/>
+![Activate Module](images/hh-docs-activate-module.png)
 
 **Updating modules manually:**
 1. Unpack the `module_update.zip` file and overwrite the original files with new ones.
 2. Navigate to **Administration > Information > Database** to perform possible database migrations.
 
-<img src="images/hh-docs-perform-migrations.png" alt="Perform DB Migrations" height="256px"/>
+![Perform DB Migrations](images/hh-docs-perform-migrations.png)
 
-3. Navigate to **Administration > Settings > Advanced** and click the **Save and flush cache** button.
+3. Navigate to **Administration > Settings > Advanced** and click the **Save & Flush Caches** button.
 
-<img src="images/hh-docs-flush-cache.png" alt="Flush Cache" height="256px"/>
+![Flush Cache](images/hh-docs-flush-cache.png)
 
 ## Firewall / Whitelist
 


### PR DESCRIPTION
Reverted `<img/>` to markdown default syntax `![alt](source)` as it is used in the rest of the documentation. Hopefully, now everything will work.