### PR TITLE
Remove 2 suffix to updating-migration2

### DIFF
--- a/docs/admin/updating-migration.md
+++ b/docs/admin/updating-migration.md
@@ -1,5 +1,5 @@
 ---
-id: updating-migration2
+id: updating-migration
 title: Migration Guide for Administrators
 sidebar_label: Migration Guide
 ---
@@ -230,4 +230,3 @@ extract it to your webroot or install it via [GitHub/Composer](../develop/enviro
 ```
 php yii search/rebuild
 ```
-

--- a/sidebars.js
+++ b/sidebars.js
@@ -75,7 +75,7 @@ module.exports = {
         ],
         'Updating': [
             'admin/updating',
-            'admin/updating-migration2',
+            'admin/updating-migration',
         ],        
     },
     Developement: {


### PR DESCRIPTION
This PR removes the 2 at the end of `https://docs.humhub.org/docs/admin/updating-migration2` URL

@luke- Should I rebuild the doc?

If yes, I have errors with both npm and yarn:

```sh
$ yarn
00h00m00s 0/0: : ERROR: There are no scenarios; must have at least one.
```

```sh
npm run build

> humhub-doc@0.0.0 start
> docusaurus start

file:///home/marc/www/documentation/node_modules/@docusaurus/core/bin/docusaurus.mjs:30
process.env.BABEL_ENV ??= 'development';
                       ^

SyntaxError: Unexpected token '?'
    at Loader.moduleStrategy (internal/modules/esm/translators.js:133:18)
    at async link (internal/modules/esm/module_job.js:42:21)
```