### PR TITLE
Add Search Syntax Docs

### DIFF
--- a/docs/admin/search.md
+++ b/docs/admin/search.md
@@ -5,10 +5,11 @@ title: Search
 
 **The built in search system is used for:**
 
-- Directory
-- People/Space Search
-- Content Search
-- User/Space Picker Widgets
+- Content
+- People
+- Spaces
+- Marketplace
+- Third-party resources ("[Advanced Search](https://marketplace.humhub.com/module/advanced-search/description)" - [HumHub Professional Edition](../professional-edition/intro.md) module)
 
 ## Content Search - Index Rebuilding
 


### PR DESCRIPTION
I changed the main title because mentioning HumHub in HumHub’s docs seemed redundant, plus I added “cheat sheet” to maybe make it clearer what it is. Also, the intro needs a check.

https://github.com/humhub/office_tasks/issues/430