### PR TITLE
Fix typo in installation instructions for Apache

### DIFF
--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -148,7 +148,7 @@ cd /var/www/humhub
 cp .htaccess.dist .htaccess
 ```
 
-Sometimes it is necessary to enable support for ``.htaccess`` files in the [Apache VirtualHost](server-setup.md#apache) via the ``AllowOverwrite all`` directive. 
+Sometimes it is necessary to enable support for ``.htaccess`` files in the [Apache VirtualHost](server-setup.md#apache) via the ``AllowOverride all`` directive. 
 
 
 Example VirtualHost configuration:


### PR DESCRIPTION
The directive is `AllowOverride` as correctly used on the example block.