### PR TITLE
Update minimum and recommended database versions

### DIFF
--- a/docs/admin/requirements.md
+++ b/docs/admin/requirements.md
@@ -71,8 +71,15 @@ This is just a short overview. See the [PHP Manual](https://www.php.net/manual/e
 
 ## Database
 
-- **MariaDB 10.1+**
-- **MySQL 5.7+**
+Minimum supported versions:
+
+- **MariaDB 10.11+**
+- **MySQL 8.0+**
+
+Recommended versions:
+
+- **MariaDB 11.8+**
+- **MySQL 8.4+**
 
 **Utf8mb4** character set and **InnoDB** storage engine are required.
 


### PR DESCRIPTION
Updates the documented database requirements to reflect the minimum supported and recommended versions.

- Minimum supported: **MariaDB 10.11+ / MySQL 8.0+** (was MariaDB 10.1+ / MySQL 5.7+)
- Recommended: **MariaDB 11.8+ / MySQL 8.4+**

MySQL 5.7 is EOL (since October 2023). These versions align with the core CI matrix and coding-standards test matrix.

Refs:
- humhub/humhub#8255
- humhub/module-coding-standards#10