### PR TITLE
Restructure footer navigation and legal links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,26 +97,9 @@ module.exports = {
               label: 'HumHub Translation',
               href: 'https://translate.humhub.org',
             },
-          ],
-        },
-        {
-          title: 'Social',
-          items: [
-           /* {
-              label: 'Blog',
-              to: 'blog',
-            },*/
             {
               label: 'GitHub',
               href: 'https://github.com/humhub/humhub',
-            },
-            {
-              label: 'Twitter',
-              href: 'https://twitter.com/humhub',
-            },
-            {
-              label: 'Facebook',
-              href: 'https://www.facebook.com/thehumhub'
             },
           ],
         },
@@ -128,8 +111,8 @@ module.exports = {
               href: 'https://www.humhub.com',
             },
             {
-              label: 'Licenses',
-              href: 'https://www.humhub.com/licenses/',
+              label: 'News',
+              href: 'https://community.humhub.com/s/announcements/',
             },
             {
               label: 'Marketplace',
@@ -137,8 +120,33 @@ module.exports = {
             },
           ],
         },
+        {
+          title: 'Legal',
+          items: [
+            {
+              label: 'Privacy Policy',
+              href: 'https://www.humhub.com/legal/privacy/',
+            },
+            {
+              label: 'Cookie Policy',
+              href: 'https://www.humhub.com/legal/cookies/',
+            },
+            {
+              label: 'Terms of Service',
+              href: 'https://www.humhub.com/legal/terms/',
+            },
+            {
+              label: 'Licenses',
+              href: 'https://www.humhub.com/licenses/',
+            },
+            {
+              label: 'Imprint',
+              href: 'https://www.humhub.com/legal/imprint/',
+            },
+          ],
+        },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} HumHub. All rights reserved.  `,
+      copyright: `Copyright © ${new Date().getFullYear()} HumHub GmbH &amp; Co. KG`,
     },
   },
   presets: [


### PR DESCRIPTION
## Summary

Restructures the site footer to align it with the HumHub homepage and remove dead-end/duplicate entries.

## Changes

- **Removed the Social column.** GitHub moved into **Community**; Twitter and Facebook dropped.
- **Community** now: HumHub Community, HumHub Translation, GitHub.
- **More** (now the third column): Homepage, **News**, Marketplace. Added the homepage's **News** link (`community.humhub.com/s/announcements/`) and removed the Licenses entry (moved to Legal).
- **New Legal column**, adopted from the homepage footer and linking to the corresponding pages: Privacy Policy, Cookie Policy, Terms of Service, Licenses, Imprint (same order as the homepage). The interactive "Cookie settings" item is intentionally omitted, as its consent widget does not apply to the docs site.
- **Copyright** adopted from the homepage: `Copyright © <year> HumHub GmbH & Co. KG` (dynamic year).

## Verification

`npm run build` passes with no broken links or anchors. All external footer URLs were checked and return 200 with no redirects.
